### PR TITLE
docs(substrate): encode GitHub immutable substrate model and rebase-merge values

### DIFF
--- a/docs/decisions/ADR-005-rebase-merge-as-substrate-preservation.md
+++ b/docs/decisions/ADR-005-rebase-merge-as-substrate-preservation.md
@@ -1,0 +1,67 @@
+# ADR-005: Rebase-and-Merge as the Canonical PR Merge Strategy
+
+**Date**: 2026-03-07
+**Status**: Accepted
+**Deciders**: EndogenAI core team
+
+---
+
+## Context
+
+This project treats the git commit graph and GitHub's application layer as **a multi-layered immutable substrate** — a passive side-effect of using GitHub that encodes every decision, correction, and agent action in a cryptographically addressed, content-immutable record.
+
+The three substrate layers, from most durable to least:
+
+| Layer | Durability | What it records |
+|---|---|---|
+| **git object store** | Cryptographic — content-addressed by SHA; objects persist unless garbage-collected | Every file state ever committed; every commit ever made on any branch |
+| **GitHub PR + review layer** | Application-level immutable — PR pages survive merges; reviews/comments are permanent | Intent, reasoning, inline corrections, agent decisions at review time |
+| **`main` commit log** | Durable but shaped by merge strategy — the traversable history of the project | Agent decisions encoded as Conventional Commit messages; the "tree rings" of the project |
+
+The **merge strategy** directly governs the quality of Layer 3. Squash-merging collapses N branch commits into one new SHA on `main`. The original commits become **dangling git objects** — preserved in the git object store (Layer 1) but unreachable from `main` via `git log`, `git bisect`, or `git blame`. They are also visible on the GitHub PR page (Layer 2) but not as first-class traversable history.
+
+This repo uses [Conventional Commits](https://www.conventionalcommits.org/) as a deliberate encoding convention — each `type(scope): message` commit is a discrete, dated record of an agent or human decision. Squash-merging degrades this encoding: instead of 5 granular fix commits tracing a debugging sequence, `main` shows one aggregate entry. The density of the tree rings is reduced.
+
+Three merge strategies were evaluated:
+
+| Strategy | Layer 3 quality | Notes |
+|---|---|---|
+| **Squash merge** | Degraded — N commits → 1 per PR | History readable but encoding granularity lost |
+| **Merge commit** | Full — all commits + merge commit | Merges add noise to `main`; non-linear history |
+| **Rebase and merge** | Full — all commits, linear | No merge commit noise; linear `git log`; ideal for Conventional Commits |
+
+## Decision
+
+**Use rebase-and-merge exclusively. Disable squash merge and merge commit in repository settings.**
+
+All PRs must be merged via "Rebase and merge" in the GitHub UI. This ensures:
+- Every commit on every PR branch lands on `main` individually, in chronological order
+- `git log --oneline main` reads as a coherent, granular Conventional Commits history
+- `git bisect` has maximum precision — bugs can be isolated to a single commit
+- `git blame` traces each line to the specific agent decision that introduced it
+- The tree rings of the project are dense and readable
+
+## Consequences
+
+- **Contributors must keep PR commits clean**: since every commit lands on `main`, each should be a valid Conventional Commit. Fix-up commits (`fixup!`) should be squashed before PR review, not via GitHub's squash option.
+- **`AGENTS.md` guardrail**: agents making commits on PR branches must follow Conventional Commits format, because those commits will be `main` history.
+- **Documented in**: `docs/toolchain/git.md` (PR merge strategy row), `docs/guides/github-workflow.md` (section 9), `CONTRIBUTING.md` (Pull Request section).
+- **Repository setting**: Settings → General → Pull Requests → uncheck "Allow squash merging" and "Allow merge commits"; check "Allow rebase merging".
+- **Existing history**: Prior to 2026-03-07, squash merge was the default. All PR35 and earlier merges are single squash commits on `main`. This is noted for archaeology but does not invalidate the decision going forward.
+
+## Connection to Endogenic Values
+
+This decision is an instance of the **tree rings principle** from `docs/guides/mental-models.md`:
+
+> *"Commit incrementally — each commit is a dated, complete unit of work. Future sessions can see what changed, why, and when."*
+
+It is also an instance of the **Endogenous-First axiom**: the git commit log is part of the system's inherited knowledge. Degrading that record with squash merges reduces what agents can learn from the project's history.
+
+## References
+
+- [`docs/guides/mental-models.md`](../guides/mental-models.md) — Tree Rings metaphor
+- [`docs/research/github-as-memory-substrate.md`](../research/github-as-memory-substrate.md) — P4: Commit archaeology, Layer architecture
+- [`docs/guides/github-workflow.md`](../guides/github-workflow.md) — Section 9: PR Merge Strategy
+- [`docs/toolchain/git.md`](../toolchain/git.md) — PR Merge Strategy section
+- Issue [#36](https://github.com/EndogenAI/Workflows/issues/36) — decision trigger
+- PR [#37](https://github.com/EndogenAI/Workflows/pull/37) — initial documentation

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -35,3 +35,4 @@ Write an ADR when:
 | [ADR-002](ADR-002-kanban-not-scrum.md) | Kanban over Scrum for project planning | Accepted | 2026-03-07 |
 | [ADR-003](ADR-003-xml-hybrid-agent-format.md) | XML-hybrid format for agent instruction files | Proposed | 2026-03-07 |
 | [ADR-004](ADR-004-no-coverage-threshold.md) | No CI coverage percentage threshold | Accepted | 2026-03-07 |
+| [ADR-005](ADR-005-rebase-merge-as-substrate-preservation.md) | Rebase-and-merge to preserve commit encoding substrate | Accepted | 2026-03-07 |

--- a/docs/guides/mental-models.md
+++ b/docs/guides/mental-models.md
@@ -79,6 +79,32 @@ When you **add a new script, new agent, or new guide**, you are adding a visible
 
 When you **run a research session and commit the results**, that session is a tree ring. Thick rings are productive sessions with many commits. Thin rings are focused sessions. The pattern of rings over time tells the story of the project's evolution.
 
+### GitHub's Layered Immutable Substrate
+
+Using GitHub creates immutable layers as a **passive side-effect** — not something you have to explicitly manage. This is one of the most underappreciated properties of the system: every action leaves a durable trace even when nothing is "saved" deliberately.
+
+```
+Layer 1 — git object store (most durable)
+  Content-addressed by SHA; cryptographically immutable.
+  Every file, tree, and commit object ever created persists here.
+  Objects only disappear via explicit garbage collection.
+
+Layer 2 — GitHub application layer (application-immutable)
+  PR pages, review comments, issue comments, activity feeds.
+  These survive branch deletion and merges.
+  A PR from two years ago still shows every inline review thread.
+
+Layer 3 — main commit log (traversable history)
+  The "readable tree rings" — what git log, git bisect, and git blame see.
+  Shaped by merge strategy: rebase preserves granularity; squash collapses it.
+```
+
+**Implication for tool choices**: any decision about how you interact with git (merge strategy, commit discipline, branch naming) is a **substrate design decision**, not just a workflow preference. Choosing squash-merge does not destroy Layer 1 or Layer 2 — but it degrades Layer 3, reducing `main`'s history from a dense readable record of agent decisions into a sparse sequence of aggregate PR blobs.
+
+**The tree rings connection**: each Conventional Commit that lands on `main` is a dated ring. Squash-merging is the equivalent of reporting a decade of growth as a single ring with no internal structure — the total mass is there, but the annual story is gone.
+
+This is why the rebase-and-merge policy exists: see [ADR-005](../decisions/ADR-005-rebase-merge-as-substrate-preservation.md).
+
 ---
 
 ## How the Three Metaphors Interlock

--- a/docs/research/github-as-memory-substrate.md
+++ b/docs/research/github-as-memory-substrate.md
@@ -175,6 +175,68 @@ docs/research/ + docs/guides/
 
 ---
 
+## 4a. The Immutable Substrate Model
+
+GitHub creates **layered immutable substrate** as a passive side-effect of normal use. This distinction matters for substrate design decisions (e.g. merge strategy, branch discipline, commit message quality):
+
+```
+Layer 1 — git object store
+  Content-addressed by SHA (SHA-1 for legacy git, SHA-256 for git 2.29+).
+  Every blob, tree, commit, and tag object is cryptographically immutable.
+  Objects persist even when branches are deleted; only explicit GC removes them.
+  Durability: near-permanent (GitHub retains objects well past branch deletion)
+
+Layer 2 — GitHub application layer (PR + issue + review records)
+  PR pages, inline review threads, issue comments, activity timeline.
+  Immutable at the application level — these records survive merges and deletions.
+  A PR merged 2 years ago still shows every commit that was in it.
+  Durability: permanent while the repository exists
+
+Layer 3 — main commit log (the traversable tree rings)
+  What git log, git bisect, git blame, and agent context queries actually see.
+  This layer is SHAPED by merge strategy — it is not automatically immutable.
+  Rebase merge: all branch commits land on main linearly (dense rings)
+  Squash merge: N commits → 1 per PR (sparse rings; granularity lost from main)
+```
+
+### Why merge strategy is a substrate design decision
+
+A squash merge does not destroy Layer 1 or Layer 2. The original commits are still in the git object store, and the PR page still lists them. But they are **no longer reachable from any branch ref** — they cannot be traversed by `git log main`, cannot be isolated by `git bisect`, and cannot be attributed by `git blame` to their original author and message.
+
+For this repo, where Conventional Commit messages are a deliberate encoding of agent decisions (each `type(scope): message` is a dated record of *why* a change was made), squash-merging degrades Layer 3 from a dense, granular decision log to a sequence of PR-level summaries.
+
+**Decision**: rebase-and-merge is the canonical strategy. See [ADR-005](../decisions/ADR-005-rebase-merge-as-substrate-preservation.md).
+
+### Retrieval implications
+
+| What you want to find | Layer | Tool | Notes |
+|---|---|---|---|
+| "What was in PR #35?" | Layer 2 | `gh pr view 35 --json commits` | Always available; not affected by merge strategy |
+| "What commits touched scripts/ in last 30 days?" | Layer 3 | `git log --oneline -- scripts/` | Requires rebase merge for full granularity |
+| "When was this line last changed and why?" | Layer 3 | `git blame <file>` | Squash merge attributes all lines to the squash commit |
+| "Find the commit that introduced bug X" | Layer 3 | `git bisect` | Granularity of bisect search == granularity of Layer 3 |
+| "What's the original SHA of a pre-merge commit?" | Layer 1 | `gh pr view <n> --json commits` | Always recoverable from Layer 2 → Layer 1 |
+
+---
+
+```
+.tmp/<branch>/<date>.md
+  ↓ Working memory — ephemeral, local, fast write/read
+
+GitHub Issues + PR descriptions + git log (Conventional Commits)
+  ↓ Episodic memory — durable, searchable, queryable by label/number
+
+docs/research/ + docs/guides/
+  ↓ Semantic memory — distilled, validated patterns
+
+/memories/repo/ (Copilot memory tool)
+  ↓ Cross-session heuristics — Copilot-readable, persisted across workspaces
+```
+
+**GitHub Projects v2** remains a human coordination surface. Copilot cannot read field values. Do not design agent workflows that depend on project field state for retrieval — encode state in labels instead.
+
+---
+
 ## 5. Limitations and Trade-offs
 
 | Limitation | Detail |


### PR DESCRIPTION
## Summary

Encodes the GitHub immutable substrate model into the project's documentation and decision records. This is the philosophical companion to PR #37 (`chore/disable-squash-merge`) — where that PR changes the policy, this one explains **why** the policy matters and connects it to the project's core values.

## Files changed

| File | Change |
|------|--------|
| `docs/decisions/ADR-005-rebase-merge-as-substrate-preservation.md` | **New ADR** — formal decision record for the rebase-and-merge policy; introduces the three-layer immutable substrate model and connects it to the Endogenous-First axiom and the tree rings metaphor |
| `docs/decisions/README.md` | Add ADR-005 to the decision log |
| `docs/guides/mental-models.md` | Extend the Tree Rings section with a new "GitHub's Layered Immutable Substrate" subsection: ASCII three-layer diagram, tool-choice implications, link to ADR-005 |
| `docs/research/github-as-memory-substrate.md` | Add Section 4a "The Immutable Substrate Model" — layer diagram with durability ratings, merge strategy analysis, retrieval implications table, link to ADR-005 |

## The core model encoded

```
Layer 3 — main commit log        (merge-strategy-dependent; Conventional Commits encoding)
Layer 2 — GitHub application layer   (PRs, reviews, issues; application-immutable)
Layer 1 — git object store       (content-addressed SHAs; cryptographically permanent)
```

Every tool choice that affects git history is a substrate design decision, not merely a workflow preference. Squash-merging collapses Layer 3 encoding; rebase-and-merge preserves it.

## Relation to open issues

This encoding has direct research implications for #31, #32, #13, #9 — comments have been posted on each.

## Depends on

This PR is independent of PR #37 and can be merged in either order.

@AccessiT3ch @copilot — please review.
