### PR TITLE
fix(scripts,tests,docs): address PR #436 review comments

### DIFF
--- a/docs/plans/2026-03-25-next-sprint-recommendation.md
+++ b/docs/plans/2026-03-25-next-sprint-recommendation.md
@@ -263,7 +263,7 @@ Parallel Track (Research & Secondary Work)
 These are solid future work but not critical for the next 2 weeks:
 
 - RAG/Knowledge Systems (#358, #352–#355, #359) — defer to Q2 Wave 2
-- Testing & Release Harnesss (#428, #350, #113) — defer pending Wave 1 stabilization
+- Testing & Release Harness (#428, #350, #113) — defer pending Wave 1 stabilization
 - Long-tail research topics (#283, #131, #128) — standing backlog, not urgent
 - DevRel / Adoption (#427, #430, #429, #428) — [DEFER] items, intentionally deferred
 

--- a/scripts/check_branch_sync.py
+++ b/scripts/check_branch_sync.py
@@ -48,11 +48,19 @@ import sys
 
 def _run(cmd: list[str], *, capture: bool = True) -> subprocess.CompletedProcess[str]:
     """Run a git command and return the CompletedProcess result."""
-    return subprocess.run(
-        cmd,
-        capture_output=capture,
-        text=True,
-    )
+    try:
+        return subprocess.run(
+            cmd,
+            capture_output=capture,
+            text=True,
+        )
+    except OSError as exc:
+        # Unexpected I/O error (e.g., git not installed, bad cwd); exit 2 per docstring.
+        print(
+            f"ERROR: failed to run command: {' '.join(cmd)}\n{exc}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
 
 def fetch_remote(remote: str) -> None:

--- a/tests/test_check_branch_sync.py
+++ b/tests/test_check_branch_sync.py
@@ -13,7 +13,7 @@ Covers:
 - git log failure: git log fails → sys.exit(2)
 - Custom --remote and --base flags
 - main() callable with argv list
-- Module entrypoint (__name__ == '__main__')
+- OSError in _run(): exit 2 with error message
 
 All subprocess calls are mocked to keep tests hermetic (no real git state needed).
 Coverage target: ≥80% of scripts/check_branch_sync.py
@@ -79,6 +79,15 @@ class TestFetchRemote:
             with pytest.raises(SystemExit) as exc_info:
                 cbs_mod.fetch_remote("origin")
         assert exc_info.value.code == 2
+
+    def test_fetch_oserror_exits_2(self, cbs_mod, capsys):
+        """OSError (e.g. git not installed) must exit 2, not raise an unhandled traceback."""
+        with patch("subprocess.run", side_effect=OSError("git not found")):
+            with pytest.raises(SystemExit) as exc_info:
+                cbs_mod.fetch_remote("origin")
+        assert exc_info.value.code == 2
+        err = capsys.readouterr().err
+        assert "git not found" in err
 
     def test_fetch_custom_remote(self, cbs_mod):
         with patch("subprocess.run", return_value=_completed(0)) as mock_run:


### PR DESCRIPTION
Addresses 3 actionable inline review comments from Copilot on the already-merged PR #436:

1. **`check_branch_sync.py`** — wrap `subprocess.run` in `_run()` with `try/except OSError`, exits 2 with error message instead of an unhandled traceback when git is not installed or the cwd is deleted.
2. **`tests/test_check_branch_sync.py`** — add `test_fetch_oserror_exits_2` covering the new OSError path; remove false `__name__ == '__main__'` coverage claim from the module docstring.
3. **`docs/plans/2026-03-25-next-sprint-recommendation.md`** — fix `Harnesss` → `Harness` typo (line 266).

The 4th comment (sprint plan doc in diff not mentioned in PR description) was advisory — no code change required.

Follow-up to #436.
