### PR TITLE
fix(dashboard): eliminate 404s during browser bridge polling

### DIFF
--- a/scripts/start_dashboard.py
+++ b/scripts/start_dashboard.py
@@ -65,7 +65,10 @@ def _spawn_processes(repo_root: Path, *, development: bool = False) -> tuple[sub
         "8000",
     ]
     if development:
-        sidecar_cmd.append("--reload")
+        # Scope the watcher to web/ only — the repo root contains many Python
+        # files (scripts/, tests/, mcp_server/) whose edits should not restart
+        # the sidecar and orphan active browser bridge sessions.
+        sidecar_cmd.extend(["--reload", "--reload-dir", str(web_dir)])
     frontend_cmd = ["npm", "run", "dev"]
 
     # Inherit full environment (includes WEBMCP_CORS_ORIGINS when set)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -524,13 +524,27 @@ def test_browser_poll_returns_204_when_session_replaced_during_wait(tmp_path, mo
     waiting, the in-flight poll must return 204 (graceful no-work) rather than
     404.  This covers the HMR / page-reload race: register_browser() calls
     notify_all() which wakes the waiting poll; the poll sees the session was
-    replaced and returns None instead of raising HTTPException(404)."""
-    import time as _time
+    replaced and returns None instead of raising HTTPException(404).
+
+    Synchronisation: a threading.Event is signalled from inside
+    Condition.wait so we can be certain the poll thread is blocked in the
+    condition before we replace the session.  This eliminates the fixed-sleep
+    race that can cause intermittent failures on slow/loaded CI."""
 
     client = _make_client(monkeypatch, tmp_path / "nonexistent.jsonl")
     session_id = client.post("/mcp/browser/session").json()["sessionId"]
 
     poll_status: dict[str, int] = {}
+    entered_wait = threading.Event()
+    _original_condition_wait = threading.Condition.wait
+
+    def _spy_condition_wait(self, timeout=None):
+        entered_wait.set()
+        return _original_condition_wait(self, timeout=timeout)
+
+    # Patch Condition.wait for the duration of this test so we know exactly
+    # when the poll thread has entered its blocking wait.
+    monkeypatch.setattr(threading.Condition, "wait", _spy_condition_wait)
 
     def _do_poll() -> None:
         poll_status["status_code"] = client.get(f"/mcp/browser/poll?session_id={session_id}&wait=2").status_code
@@ -538,8 +552,8 @@ def test_browser_poll_returns_204_when_session_replaced_during_wait(tmp_path, mo
     poll_thread = threading.Thread(target=_do_poll)
     poll_thread.start()
 
-    # Allow the poll thread to enter the condition.wait() before we replace the session.
-    _time.sleep(0.1)
+    # Block until the poll thread is provably inside condition.wait().
+    assert entered_wait.wait(timeout=5), "Poll thread did not enter condition.wait() within 5 s"
 
     # Registering a new session calls notify_all(), waking the in-flight poll.
     client.post("/mcp/browser/session")

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -516,3 +516,34 @@ def test_browser_session_replacement_invalidates_old_session(tmp_path, monkeypat
 
     active_poll = client.get(f"/mcp/browser/poll?session_id={second_session}&wait=0")
     assert active_poll.status_code == 204
+
+
+@pytest.mark.integration
+def test_browser_poll_returns_204_when_session_replaced_during_wait(tmp_path, monkeypatch):
+    """When a new session registration replaces the active one while a poll is
+    waiting, the in-flight poll must return 204 (graceful no-work) rather than
+    404.  This covers the HMR / page-reload race: register_browser() calls
+    notify_all() which wakes the waiting poll; the poll sees the session was
+    replaced and returns None instead of raising HTTPException(404)."""
+    import time as _time
+
+    client = _make_client(monkeypatch, tmp_path / "nonexistent.jsonl")
+    session_id = client.post("/mcp/browser/session").json()["sessionId"]
+
+    poll_status: dict[str, int] = {}
+
+    def _do_poll() -> None:
+        poll_status["status_code"] = client.get(f"/mcp/browser/poll?session_id={session_id}&wait=2").status_code
+
+    poll_thread = threading.Thread(target=_do_poll)
+    poll_thread.start()
+
+    # Allow the poll thread to enter the condition.wait() before we replace the session.
+    _time.sleep(0.1)
+
+    # Registering a new session calls notify_all(), waking the in-flight poll.
+    client.post("/mcp/browser/session")
+
+    poll_thread.join(timeout=5)
+    assert not poll_thread.is_alive(), "Poll thread did not complete within 5 s"
+    assert poll_status["status_code"] == 204

--- a/web/server.py
+++ b/web/server.py
@@ -230,7 +230,15 @@ class BrowserInspectorBridge:
                 if not self._pending_requests:
                     self._condition.wait(timeout=wait_seconds)
 
-                self._require_session(session_id)
+                # Session may have been replaced while waiting (e.g. page HMR
+                # reload calls register_browser, which calls notify_all).
+                # Return None (→ 204) rather than raising 404 so the client
+                # gets a clean no-work response and re-polls immediately;
+                # the stale session_id then fails the first-check on the next
+                # round, and the client re-registers.
+                if self._session_id != session_id or not self._session_is_live():
+                    return None
+
                 self._last_seen_monotonic = time.monotonic()
 
                 if not self._pending_requests:

--- a/web/src/lib/mcp-server.ts
+++ b/web/src/lib/mcp-server.ts
@@ -451,6 +451,14 @@ export class BrowserMcpServer {
           continue;
         }
 
+        if (response.status === 404) {
+          // 404 means the session was not found (expired or server restarted).
+          // Re-register immediately — no back-off needed for this known-recoverable state.
+          this.bridgeSessionId = null;
+          this.emitStatus('CONNECTING');
+          continue;
+        }
+
         if (!response.ok) {
           this.bridgeSessionId = null;
           this.emitStatus('CONNECTING');

--- a/web/src/lib/mcp-server.ts
+++ b/web/src/lib/mcp-server.ts
@@ -143,7 +143,7 @@ export class BrowserMcpServer {
   private bridgeSessionId: string | null = null;
   private bridgeLoop: Promise<void> | null = null;
   private bridgeAbortController: AbortController | null = null;
-  private pagehideListener: (() => void) | null = null;
+  private pagehideListener: ((event: PageTransitionEvent) => void) | null = null;
   private started = false;
 
   constructor(options: BrowserMcpServerOptions = {}) {
@@ -173,8 +173,27 @@ export class BrowserMcpServer {
     // Abort the bridge loop when the page unloads (hard refresh / navigation away).
     // Without this, the old loop survives into the next page load and races with the
     // new page's loop for the server session, causing immediate 404s.
-    const onPageHide = () => {
+    //
+    // BFCache (back/forward cache) consideration: pagehide also fires when the page
+    // is frozen into BFCache (event.persisted === true).  In that case we still abort
+    // any in-flight fetch (the browser freezes it anyway), but we must also reset
+    // `started` so start() can re-attach when the user navigates back, and register
+    // a pageshow handler to restart the bridge loop on restoration.
+    const onPageHide = (event: PageTransitionEvent) => {
       this.bridgeAbortController?.abort();
+      if (event.persisted) {
+        // Page is entering BFCache — will be restored via pageshow.
+        this.started = false;
+        window.addEventListener(
+          'pageshow',
+          (showEvent: PageTransitionEvent) => {
+            if (showEvent.persisted) {
+              void this.start();
+            }
+          },
+          { once: true }
+        );
+      }
     };
     this.pagehideListener = onPageHide;
     window.addEventListener('pagehide', onPageHide, { once: true });
@@ -191,7 +210,10 @@ export class BrowserMcpServer {
 
   async stop(): Promise<void> {
     if (this.pagehideListener) {
-      window.removeEventListener('pagehide', this.pagehideListener);
+      window.removeEventListener(
+        'pagehide',
+        this.pagehideListener as EventListenerOrEventListenerObject
+      );
       this.pagehideListener = null;
     }
     this.bridgeAbortController?.abort();

--- a/web/src/lib/mcp-server.ts
+++ b/web/src/lib/mcp-server.ts
@@ -143,6 +143,7 @@ export class BrowserMcpServer {
   private bridgeSessionId: string | null = null;
   private bridgeLoop: Promise<void> | null = null;
   private bridgeAbortController: AbortController | null = null;
+  private pagehideListener: (() => void) | null = null;
   private started = false;
 
   constructor(options: BrowserMcpServerOptions = {}) {
@@ -169,6 +170,15 @@ export class BrowserMcpServer {
     this.bridgeAbortController = new AbortController();
     this.bridgeLoop = this.runBridgeLoop(this.bridgeAbortController.signal);
 
+    // Abort the bridge loop when the page unloads (hard refresh / navigation away).
+    // Without this, the old loop survives into the next page load and races with the
+    // new page's loop for the server session, causing immediate 404s.
+    const onPageHide = () => {
+      this.bridgeAbortController?.abort();
+    };
+    this.pagehideListener = onPageHide;
+    window.addEventListener('pagehide', onPageHide, { once: true });
+
     if (!this.enableSseProbe) return;
 
     // SSE alignment: EventSource over HTTP, no WebSocket transport in this phase.
@@ -180,6 +190,10 @@ export class BrowserMcpServer {
   }
 
   async stop(): Promise<void> {
+    if (this.pagehideListener) {
+      window.removeEventListener('pagehide', this.pagehideListener);
+      this.pagehideListener = null;
+    }
     this.bridgeAbortController?.abort();
     this.bridgeAbortController = null;
     try {


### PR DESCRIPTION
## Problem

The MCP Dashboard browser bridge was 404ing continuously during polling. Three bugs compounded each other:

1. **`start_dashboard.py` — over-broad `--reload` watcher**: uvicorn watched the entire repo root in dev mode, so any `.py` edit in `scripts/`, `tests/`, or `mcp_server/` restarted the sidecar and destroyed the in-memory `BrowserInspectorBridge`, orphaning the active session.

2. **`web/server.py` — `_wait_for_request` raised 404 during HMR**: A second `_require_session` call fired *after* the condition wait. When Vite HMR triggered `register_browser()` mid-wait (which calls `notify_all()`), the session had already been replaced — so the woken thread raised `HTTPException(404)` instead of returning gracefully.

3. **`mcp-server.ts` — 404 response triggered a 500ms back-off before re-registering**: A 404 is a known-recoverable "session not found" state; the delay was unnecessary and extended the broken window.

4. **`mcp-server.ts` — old bridge loop survived hard refresh**: Svelte's `onMount` cleanup (`disableBridge`) is not guaranteed to fire before the JS context tears down on a hard refresh. The old loop received the new graceful 204, re-polled with the stale session ID, got 404, then re-registered — replacing the new page's fresh session. Both loops fought indefinitely.

## Fixes

| Commit | File | Fix |
|--------|------|-----|
| `d2ded7b` | `scripts/start_dashboard.py` | Scope `--reload-dir` to `web/` only |
| `d2ded7b` | `web/server.py` | Replace second `_require_session` with graceful `None` return → 204 |
| `d2ded7b` | `web/src/lib/mcp-server.ts` | Handle 404 with immediate re-registration, no back-off sleep |
| `f5d3fe0` | `web/src/lib/mcp-server.ts` | Register `pagehide` listener in `start()` to abort the loop on unload |

## Tests

- Existing 22 web server tests: all pass
- New `@pytest.mark.integration` test: `test_browser_poll_returns_204_when_session_replaced_during_wait` — covers the concurrent session-replacement race (fix 2)