### PR TITLE
fix(agents): patch PR Review Triage Gate encoding gaps (#565)

### DIFF
--- a/.github/agents/executive-orchestrator.agent.md
+++ b/.github/agents/executive-orchestrator.agent.md
@@ -570,14 +570,15 @@ When all phases are complete:
 **Before suggesting merge or treating any open PR as ready to merge — run the PR Review Triage Gate:**
 
 ```bash
-# Step 0: Wait for Copilot review to land before checking (do NOT skip — review posts async after PR open)
-uv run python scripts/wait_for_pr_review.py <pr> --min-reviews 1
+# Step 0: Derive PR number from the current branch (must come first — later steps depend on it)
+PR_NUM=$(gh pr view --json number -q '.number' 2>/dev/null) && echo "PR #$PR_NUM found" || echo "No PR open — skip triage"
 
-# Step 1: Check for any open PR on this branch
-gh pr view --json number,state,reviews,reviewThreads 2>/dev/null || echo "No PR open"
+# Step 1: Wait for Copilot review to land before checking (do NOT skip — review posts async after PR open)
+uv run python scripts/wait_for_pr_review.py "$PR_NUM" --min-reviews 1
 
-# Step 2: Retrieve all inline comments
-gh api repos/<owner>/<repo>/pulls/<num>/comments --jq '.[] | {id, path, body}'
+# Step 2: Retrieve reviews and all inline comments
+gh pr view "$PR_NUM" --json reviews 2>/dev/null
+gh api repos/<owner>/<repo>/pulls/"$PR_NUM"/comments --jq '.[] | {id, path, body}'
 ```
 
 Triage every review comment (Blocking / Suggestion / Nit / Question) before treating the session as closed. A "PR is open — ready to merge" statement without this step is an encoding failure. **Never execute `gh pr merge` or suggest merge without explicit user "go ahead" in the current session — CI pass ≠ merge authorization.** See [AGENTS.md § PR Review Triage Gate](../../AGENTS.md#pr-review-triage-gate) and [pr-review-triage skill](../../.github/skills/pr-review-triage/SKILL.md).

--- a/.github/agents/executive-orchestrator.agent.md
+++ b/.github/agents/executive-orchestrator.agent.md
@@ -438,6 +438,12 @@ Before starting any task, ask yourself:
 - Orchestrator does not commit, push, or invoke gh directly
 - Exception: `git status`, `git log --oneline` for state queries only
 
+❌ Merging a PR (`gh pr merge`):
+- Always run the PR Review Triage Gate first (§ 6 Session Close) — including `wait_for_pr_review.py`
+- Always obtain explicit user "go ahead" in the current session before any merge action
+- Never self-authorize: CI pass + Review APPROVED ≠ permission to merge
+- Exception: None
+
 ❌ GitHub content creation (labels, milestones, issue seeding):
 - Use Executive PM exclusively
 
@@ -564,14 +570,17 @@ When all phases are complete:
 **Before suggesting merge or treating any open PR as ready to merge — run the PR Review Triage Gate:**
 
 ```bash
-# Check for any open PR on this branch
+# Step 0: Wait for Copilot review to land before checking (do NOT skip — review posts async after PR open)
+uv run python scripts/wait_for_pr_review.py <pr> --min-reviews 1
+
+# Step 1: Check for any open PR on this branch
 gh pr view --json number,state,reviews,reviewThreads 2>/dev/null || echo "No PR open"
 
-# If a PR exists, retrieve all inline comments
+# Step 2: Retrieve all inline comments
 gh api repos/<owner>/<repo>/pulls/<num>/comments --jq '.[] | {id, path, body}'
 ```
 
-Triage every review comment (Blocking / Suggestion / Nit / Question) before treating the session as closed. A "PR is open — ready to merge" statement without this step is an encoding failure. See [AGENTS.md § PR Review Triage Gate](../../AGENTS.md#pr-review-triage-gate) and [pr-review-triage skill](../../.github/skills/pr-review-triage/SKILL.md).
+Triage every review comment (Blocking / Suggestion / Nit / Question) before treating the session as closed. A "PR is open — ready to merge" statement without this step is an encoding failure. **Never execute `gh pr merge` or suggest merge without explicit user "go ahead" in the current session — CI pass ≠ merge authorization.** See [AGENTS.md § PR Review Triage Gate](../../AGENTS.md#pr-review-triage-gate) and [pr-review-triage skill](../../.github/skills/pr-review-triage/SKILL.md).
 
 ### Session Delegation Audit (Optional Post-Session Check)
 

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -56,6 +56,17 @@ https://opentelemetry.io/docs/collector/deployment/
 https://opentelemetry.io/docs/languages/python/getting-started/
 https://opentelemetry.io/docs/languages/python/instrumentation/
 
+# OpenTelemetry documentation URLs — connection failures from GitHub Actions runners.
+# Site is live; referenced in multiple docs/research/*.md files.
+# Network connectivity issues in CI environment.
+https://opentelemetry.io/docs/specs/semconv/gen-ai/
+https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/
+https://opentelemetry.io/docs/specs/otel/logs/data-model/
+
+# Stack Overflow Blog — connection failures from GitHub Actions runners.
+# Referenced in docs/research/augmentation-axiom-validation.md.
+https://stackoverflow.blog/2026/01/23/ai-can-10x-developers-in-creating-tech-debt/
+
 # Cyrille Martraire living documentation article — connection failures from
 # GitHub Actions runners. Site may be blocking CI IPs or experiencing downtime.
 # Referenced in docs/research/ synthesis documents.

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -49,6 +49,13 @@ https://spec.modelcontextprotocol.io/
 # Referenced in README.md as historical context.
 https://github.com/AccessiTech/EndogenAI/issues/35
 
+# OpenTelemetry documentation URLs — request timeouts from GitHub Actions runners.
+# Site is live; referenced in docs/research/otel-agent-instrumentation.md.
+# May be due to rate-limiting or network issues in GitHub's CI environment.
+https://opentelemetry.io/docs/collector/deployment/
+https://opentelemetry.io/docs/languages/python/getting-started/
+https://opentelemetry.io/docs/languages/python/instrumentation/
+
 # Cyrille Martraire living documentation article — connection failures from
 # GitHub Actions runners. Site may be blocking CI IPs or experiencing downtime.
 # Referenced in docs/research/ synthesis documents.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A governance framework that embeds organizational constraints into AI workflows 
 ## Contents
 
 - [What Is This Repo?](#what-is-this-repo)
-- [Why DogmaMCP?](#why-dogmamc p)
+- [Why DogmaMCP?](#why-dogmamcp)
 - [Architecture](#architecture)
 - [Core Principles](#core-principles)
 - [MCP Toolset](#mcp-toolset)


### PR DESCRIPTION
Fixes #565. Patches the PR Review Triage Gate encoding gaps in the Executive Orchestrator, plus doc/security/code-of-conduct corrections from the W2 sprint (this branch was based on `feat/w2-product-reveal-readiness-561-562-v2`).

**Changes to `.github/agents/executive-orchestrator.agent.md` (Fixes #565):**
1. **Fix A** — Add `wait_for_pr_review.py` as Step 0 of the Session Close triage gate (blocks until Copilot review lands before checking)
2. **Fix B** — Add explicit user authorization requirement: "Never execute `gh pr merge` without explicit user 'go ahead'"
3. **Fix C** — Add `❌ Merging a PR` entry to the DO NOT act directly anti-patterns block

**Additional changes included from W2 branch:**
- `README.md`: Full product landing page rewrite with "Why DogmaMCP?", MCP toolset docs, quick start flows
- `docs/plans/2026-04-30-w2-product-reveal-readiness.md`: Schedule date/tool count corrections
- `SECURITY.md`: Dependency-audit doc alignment with quarterly workflow and `.cache/cve-db.json`
- `mcp_server/README.md`: Path guidance and Research Scout `force=True` semantics clarification
- `CODE_OF_CONDUCT.md`: Updated enforcement contact email

Root cause: Gate existed only in Session Close, was missing the async review wait, and had no user authorization requirement — allowing CI pass + empty review check to be misread as merge-ready.
